### PR TITLE
Clarify which foundry.toml file to modify

### DIFF
--- a/developers/smart-contracts-guide/setup.mdx
+++ b/developers/smart-contracts-guide/setup.mdx
@@ -15,7 +15,7 @@ In this guide, we will show you how to setup the Story smart contract developmen
 1. Run `foundryup` to automatically install the latest stable version of the precompiled binaries: forge, cast, anvil, and chisel
 2. Run the following command in a new directory: `forge init`. This will create a `foundry.toml` and example project files in the project root. By default, forge init will also initialize a new git repository.
 3. Initialize a new yarn project: `yarn init`. Alternatively, you can use `npm init` or `pnpm init`.
-4. Open up your `foundry.toml` file and replace it with this:
+4. Open up your root-level `foundry.toml` file (located in the top directory of your project) and replace it with this:
 
 ```toml
 [profile.default]


### PR DESCRIPTION
## Description
Updates the setup instructions to explicitly identify which foundry.toml file developers should modify.

## Changes
- Added clarification in setup.mdx that users should modify the root-level foundry.toml file located in the top directory of their project.

## Why
The original instructions weren't clear about which foundry.toml file to edit, which could lead to confusion since there's also a foundry.toml in lib/forge-std/.