### PR TITLE
added reminder to fund testnet wallet before SDK init

### DIFF
--- a/developers/typescript-sdk/setup.mdx
+++ b/developers/typescript-sdk/setup.mdx
@@ -50,6 +50,7 @@ Next we can initiate the SDK Client. There are two ways to do this:
 Before continuing with the code below:
 
 1. Make sure to have `WALLET_PRIVATE_KEY` set up in your `.env` file.
+   - Don’t forget to fund the wallet with some testnet tokens from the [Google Faucet](https://cloud.google.com/application/web3/faucet/story/aeneid) or [Official Faucet](https://aeneid.faucet.story.foundation/)
 2. Make sure to have `RPC_PROVIDER_URL` set up in your `.env` file.
    - You can use the public default one (`https://aeneid.storyrpc.io`) or check out the other RPCs [here](/network/network-info/aeneid#rpcs).
 


### PR DESCRIPTION
- Added a helpful note under the private key setup section in the TypeScript SDK setup guide.
- Reminds developers to get testnet tokens before initializing the SDK client using their private key.
- This prevents confusion when transactions might fail due to lack of funds.