### PR TITLE
fix(docs): add missing --broadcast flag to deployment command

### DIFF
--- a/developers/smart-contracts-guide/example.mdx
+++ b/developers/smart-contracts-guide/example.mdx
@@ -303,6 +303,7 @@ forge create \
   --rpc-url https://aeneid.storyrpc.io/ \
   --private-key $PRIVATE_KEY \
   ./src/Example.sol:Example \
+  --broadcast \
   --verify \
   --verifier blockscout \
   --verifier-url https://aeneid.storyscan.io/api/ \


### PR DESCRIPTION
The --broadcast flag was missing from the `forge create` command, causing it to only perform a dry run and not actually deploy the contract. This update ensures the command broadcasts the transaction to the network.