### PR TITLE
chore: fix typo in response key name

### DIFF
--- a/sdk-reference/ipasset.mdx
+++ b/sdk-reference/ipasset.mdx
@@ -307,7 +307,7 @@ const response = await client.ipAsset.mintAndRegisterIpAssetWithPilTerms({
 console.log(`
   Token ID: ${response.tokenId}, 
   IPA ID: ${response.ipId}, 
-  License Terms ID: ${response.licenseTermsId}
+  License Terms ID: ${response.licenseTermsIds}
 `);
 ```
 


### PR DESCRIPTION
corrected response key from licenseTermId to licenseTermsIds in the console.log