### PR TITLE
Update to remove OKX explorer references

### DIFF
--- a/combined.md
+++ b/combined.md
@@ -83,7 +83,6 @@
 | :---------------------------------------------------------------------------------------------------------------------- | :---------------------------------------- | :------: |
 | [BlockScout Explorer ↗️](https://www.storyscan.io/)                                                                     | `https://www.storyscan.io/`               |    ✅    |
 | [IP Explorer ↗️](https://explorer.story.foundation) (only for IP-related actions like licensing, minting licenses, etc) | `https://explorer.story.foundation`       |    ✅    |
-| [OKX Explorer ↗️](https://www.okx.com/web3/explorer/story)                                                              | `https://www.okx.com/web3/explorer/story` |          |
 | [Stakeme Explorer ↗️](https://storyscan.app/)                                                                           | `https://storyscan.app/`                  |          |
 
 ## Staking Dashboard

--- a/network/connect/mainnet.mdx
+++ b/network/connect/mainnet.mdx
@@ -34,7 +34,6 @@ description: Information and Resources for the Story's Mainnet
 | :---------------------------------------------------------------------------------------------------------------------- | :---------------------------------------- | :------: |
 | [BlockScout Explorer ↗️](https://www.storyscan.io/)                                                                     | `https://www.storyscan.io/`               |    ✅    |
 | [IP Explorer ↗️](https://explorer.story.foundation) (only for IP-related actions like licensing, minting licenses, etc) | `https://explorer.story.foundation`       |    ✅    |
-| [OKX Explorer ↗️](https://www.okx.com/web3/explorer/story)                                                              | `https://www.okx.com/web3/explorer/story` |          |
 | [Stakeme Explorer ↗️](https://storyscan.app/)                                                                           | `https://storyscan.app/`                  |          |
 
 ## Staking Dashboard


### PR DESCRIPTION
OKX Explorer team decided to stop providing the underlying infra necessary to run a Story-based explorer