### PR TITLE
Add new block explorers and validator dashboards

### DIFF
--- a/network/connect/mainnet.mdx
+++ b/network/connect/mainnet.mdx
@@ -6,7 +6,7 @@ description: Information and Resources for the Story's Mainnet
 
 <CardGroup cols={1}>
   <Card
-    title="Connet to Mainnet"
+    title="Connect to Mainnet"
     href="https://chainid.network/chain/1514/"
     icon="house"
   >
@@ -34,19 +34,24 @@ description: Information and Resources for the Story's Mainnet
 
 ## Block Explorers
 
-| Explorer                                                                                                                | URL                                 | Official |
-| :---------------------------------------------------------------------------------------------------------------------- | :---------------------------------- | :------: |
-| [BlockScout Explorer ↗️](https://www.storyscan.io/)                                                                     | `https://www.storyscan.io/`         |    ✅    |
-| [IP Explorer ↗️](https://explorer.story.foundation) (only for IP-related actions like licensing, minting licenses, etc) | `https://explorer.story.foundation` |    ✅    |
-| [Stakeme Explorer ↗️](https://storyscan.app/)                                                                           | `https://storyscan.app/`            |          |
+| Explorer                                                                                                                | URL                                                             | Official |
+| :---------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------- | :------: |
+| [BlockScout Explorer ↗️](https://www.storyscan.io/)                                                                     | `https://www.storyscan.io/`                                     |    ✅    |
+| [IP Explorer ↗️](https://explorer.story.foundation) (only for IP-related actions like licensing, minting licenses, etc) | `https://explorer.story.foundation`                             |    ✅    |
+| [Stakeme Explorer ↗️](https://storyscan.app/)                                                                           | `https://storyscan.app/`                                        |          |
+| [Nodes.Guru ↗️](https://story.explorers.guru/)                                                                          | `https://story.explorers.guru/`                                 |          |
+| [CroutonDigital ↗️](https://explorer.crouton.digital/mainnets/story/overview)                                           | `https://explorer.crouton.digital/mainnets/story/overview`      |          |
+| [DeSpread ↗️](https://vp.despreadlabs.io/explorer/mainnet/story)                                                        | `https://vp.despreadlabs.io/explorer/mainnet/story`             |          |
+| [Noders ↗️](https://ipstoryhub.org/explorer)                                                                            | `https://ipstoryhub.org/explorer`                               |          |
 
-## Staking Dashboard
+## Staking & Validator Dashboard
 
-| Dashboard URL                                        | Official |
-| :--------------------------------------------------- | :------: |
-| [Story Dashboard](https://staking.story.foundation/) |    ✅    |
-| [Origin Stake](https://ipworld.io/)                  |          |
-| [Node.Guru](https://story.explorers.guru/)           |          |
+| Dashboard URL                                                                              | Official |
+| :----------------------------------------------------------------------------------------- | :------: |
+| [Story Dashboard](https://staking.story.foundation/)                                       |    ✅    |
+| [Node.Guru](https://story.explorers.guru/)                                                 |          |
+| [Krews](https://story-dashboard.krews.xyz/story/validators)                                |          |
+| [IT Rocket](https://itrocket.net/services/mainnet/story/analytics/validators-performance/) |          |
 
 ## Contract deployment addresses
 


### PR DESCRIPTION
Add unofficial block explorers and validator dashboards to mainnet documentation.

## Changes
- Add unofficial explorers: Nodes.Guru, CroutonDigital, DeSpread, Noders
- Remove Origin Stake from staking dashboard
- Fix typo: 'Connet to Mainnet' -> 'Connect to Mainnet'
- Fix table header: Remove extra period from 'Dashboard URL.'